### PR TITLE
Hotfix/update python kafka

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build_python2:
+  test_python2:
     # Main build process
     working_directory: ~/repo
     docker:
@@ -31,7 +31,7 @@ jobs:
           path: test-results
           destination: tr1
 
-  build_python3:
+  test_python3:
     # Main build process
     working_directory: ~/repo
     docker:
@@ -65,5 +65,5 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_python2
-      - build_python3
+      - test_python2
+      - test_python3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
-      - run: 
+      - run:
           name: Pip Install
           command: pip install -r requirements.txt
       - save_cache:
@@ -36,7 +36,7 @@ jobs:
     working_directory: ~/repo
     docker:
       # the Docker image with Cypress dependencies
-      - image: python:3.6
+      - image: python:3.7
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -44,7 +44,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
-      - run: 
+      - run:
           name: Pip Install
           command: pip install -r requirements.txt
       - save_cache:
@@ -67,4 +67,3 @@ workflows:
     jobs:
       - build_python2
       - build_python3
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps2_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: Pip Install
           command: pip install -r requirements.txt
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps2_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
             - "/usr/local/bin"
             - "/usr/local/lib/python2.7/site-packages"
@@ -43,12 +43,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - run:
           name: Pip Install
           command: pip install -r requirements.txt
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
           paths:
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,21 @@
 export PROJECT_NAME := $(notdir $(CURDIR))
-PYTHON_2_BUILD := hbl/heroku-kafka:python2.7
-PYTHON_3_BUILD := hbl/heroku-kafka:python3.7
+PYTHON_2_BUILD := python2
+PYTHON_3_BUILD := python3
 
 .PHONY: dev-build
 dev-build:
-	docker build ./ -f dockerfiles/python2.7/Dockerfile -t $(PYTHON_2_BUILD) \
-	&& docker build ./ -f dockerfiles/python3.7/Dockerfile -t $(PYTHON_3_BUILD)
+	docker-compose build
 
 .PHONY: dev-test
 dev-test:
-	docker run  --env-file .env $(PYTHON_2_BUILD) python test.py
-	docker run  --env-file .env $(PYTHON_3_BUILD) python test.py
+	docker-compose run --rm $(PYTHON_2_BUILD) python test.py
+	docker-compose run --rm $(PYTHON_3_BUILD) python test.py
+
+package:
+	docker-compose run --rm $(PYTHON_3_BUILD) python setup.py sdist bdist_wheel
+
+.PHONY: upload
+upload:
+	docker-compose run $(PYTHON_3_BUILD) python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+export PROJECT_NAME := $(notdir $(CURDIR))
+PYTHON_2_BUILD := hbl/heroku-kafka:python2.7
+PYTHON_3_BUILD := hbl/heroku-kafka:python3.7
+
+.PHONY: dev-build
+dev-build:
+	docker build ./ -f dockerfiles/python2.7/Dockerfile -t $(PYTHON_2_BUILD) \
+	&& docker build ./ -f dockerfiles/python3.7/Dockerfile -t $(PYTHON_3_BUILD)
+
+.PHONY: dev-test
+dev-test:
+	docker run  --env-file .env $(PYTHON_2_BUILD) python test.py
+	docker run  --env-file .env $(PYTHON_3_BUILD) python test.py
+

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 **THIS IS AN UNOFFICIAL PACKAGE**
 
-Heroku Kafka is a python package to help you get setup quickly and easily with Kafka on Heroku. There is an [offical package](https://github.com/heroku/kafka-helper) that is possibly more secure however it has not been updated to support python 3 correctly and does not seem to be maintained anymore. 
-
+Heroku Kafka is a python package to help you get setup quickly and easily with Kafka on Heroku. There is an [offical package](https://github.com/heroku/kafka-helper) that is possibly more secure however it has not been updated to support python 3 correctly and does not seem to be maintained anymore.
 
 ## Install
 
 The easiest way to install the package is through pip.
+
 ```
 pip install heroku-kafka
 ```
@@ -47,8 +47,8 @@ producer.send('topic_without_prefix', b"some message")
 
 For all other methods and properties refer to: [KafkaProducer Docs](https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html).
 
-
 ### Consumer
+
 ```python
 from heroku_kafka import HerokuKafkaConsumer
 
@@ -92,15 +92,19 @@ for msg in consumer:
 
 For all other methods and properties refer to: [KafkaConsumer Docs](https://kafka-python.readthedocs.io/en/master/apidoc/KafkaConsumer.html).
 
-## Known Issues 
+## Known Issues
+
 - `.assign` does not add in the topic prefix.
 - .NamedTemporaryFile may not work properly on a Windows system
 
 ## Contribution
+
 If you come across any issues feel free to fork and create a PR!
 
 ## Setup
+
 Fork the repo, setup virtualenv and pip install
+
 ```bash
 >>> git clone git@github.com:<fork-repo>.git
 >>> cd <fork-repo>
@@ -109,7 +113,8 @@ Fork the repo, setup virtualenv and pip install
 >>> pip install -r requirements.txt
 ```
 
-Create a .env file with working kafka information (that includes 2 working topics at the moment). 
+Create a .env file with working kafka information (that includes 2 working topics at the moment).
+
 ```
 KAFKA_URL=""
 KAFKA_CLIENT_CERT=""
@@ -122,14 +127,17 @@ TOPIC2=""
 ```
 
 ## Tests
+
 Please make sure that any extra code you write comes with a test, it doesn't need to be over the top but just check what you have written works.
 
 All tests at the moment require a working kafka setup as its pretty hard to check it is connecting correctly without them. This means it will also require an internet connection.
 
 To run the tests:
+
 ```bash
 >>> python test.py
 ```
 
 ## Distribution
+
 To distribute the package follow these instructions:[https://packaging.python.org/tutorials/packaging-projects/](https://packaging.python.org/tutorials/packaging-projects/).

--- a/README.md
+++ b/README.md
@@ -142,4 +142,13 @@ To run the tests:
 
 ## Distribution
 
-To distribute the package follow these instructions:[https://packaging.python.org/tutorials/packaging-projects/](https://packaging.python.org/tutorials/packaging-projects/).
+To create & upload the package:
+
+```bash
+>>> make package
+>>> make upload
+```
+
+NOTE: You will need to login to PIP to upload the package.
+
+[https://packaging.python.org/tutorials/packaging-projects/](https://packaging.python.org/tutorials/packaging-projects/)

--- a/README.md
+++ b/README.md
@@ -103,39 +103,41 @@ If you come across any issues feel free to fork and create a PR!
 
 ## Setup
 
-Fork the repo, setup virtualenv and pip install
+Fork the repo, requires [Docker](https://www.docker.com/products/docker-desktop)
 
 ```bash
 >>> git clone git@github.com:<fork-repo>.git
 >>> cd <fork-repo>
->>> virtualenv -p python3 venv
->>> source venv/bin/activate
->>> pip install -r requirements.txt
+>>> make dev-build
 ```
 
 Create a .env file with working kafka information (that includes 2 working topics at the moment).
 
 ```
-KAFKA_URL=""
-KAFKA_CLIENT_CERT=""
-KAFKA_CLIENT_CERT_KEY=""
-KAFKA_TRUSTED_CERT=""
-KAFKA_PREFIX=""
+KAFKA_URL=
+KAFKA_CLIENT_CERT=
+KAFKA_CLIENT_CERT_KEY=
+KAFKA_TRUSTED_CERT=
+KAFKA_PREFIX=
 
-TOPIC1=""
-TOPIC2=""
+TOPIC1=
+TOPIC2=
 ```
+
+NOTE: The way docker reads .env files is a bit strange. You can't have any quotes around your variable values and no new lines, replace all new lines with `\n`.
 
 ## Tests
 
+**The only way to check to see if the package work is to run the tests.**
+
 Please make sure that any extra code you write comes with a test, it doesn't need to be over the top but just check what you have written works.
 
-All tests at the moment require a working kafka setup as its pretty hard to check it is connecting correctly without them. This means it will also require an internet connection.
+All tests at the moment require a working kafka setup as its pretty hard to check it is connecting correctly without them. This means it will also require an internet connection. You can copy across the connection details from heroku's kafka environment variables - also note you will need 2 test topics.
 
 To run the tests:
 
 ```bash
->>> python test.py
+>>> make dev-test
 ```
 
 ## Distribution

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  python2:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/python2.7/Dockerfile
+    env_file:
+      - .env
+    volumes:
+      - .:/src
+    stdin_open: true
+    tty: true
+  python3:
+    build:
+      context: .
+      dockerfile: ./dockerfiles/python3.7/Dockerfile
+    env_file:
+      - .env
+    volumes:
+      - .:/src
+    stdin_open: true
+    tty: true

--- a/dockerfiles/python2.7/Dockerfile
+++ b/dockerfiles/python2.7/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2.7
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY . .
+RUN pip install -r requirements.txt

--- a/dockerfiles/python3.7/Dockerfile
+++ b/dockerfiles/python3.7/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7
+ENV PYTHONUNBUFFERED 1
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY . .
+RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 certifi==2017.11.5
 chardet==3.0.4
 click==6.7
--e git+git@github.com:HubbleHQ/heroku-kafka.git@c8da1188baf62380667cdb287ca29ba92cd0ae36#egg=heroku_kafka
 idna==2.6
-kafka-python==1.3.5
+kafka-python==1.4.6
 pkginfo==1.4.1
 python-dotenv==0.7.1
 requests==2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ idna==2.6
 kafka-python==1.4.6
 pkginfo==1.4.1
 python-dotenv==0.7.1
-requests==2.18.4
+requests==2.22.0
 requests-toolbelt==0.8.0
 tqdm==4.19.5
 twine==1.9.1
-urllib3==1.22
+urllib3==1.24.2

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     license='MIT',
     py_modules=["heroku_kafka"],
     install_requires=[
-        'kafka-python==1.3.5',
+        'kafka-python==1.4.6',
     ]
 )


### PR DESCRIPTION
With python 3.7 there were changes that meant async became a key word
kafka-python was using async in multiple places which meant they needed
to update their package to work correctly. Our build failed for this
package due to the out of date dependancy.

We have updated the python version for the tests as well as the package
to make sure everything is still working as it should be.

Also updated 2 other libraries that were out of date and we were previously blocked from updating due to using the out of date kafka-python library.

NOTE: Also added docker box and Makefile so it is easier to run tests and upload. The final upload functionality I have not tested yet as I didn't want to upload this to PIP until approved.