### PR TITLE
Get twine upload working and allow circleci to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,55 @@
 version: 2
 
+# Base python 3 setup 
+python3: &python3
+  working_directory: ~/repo
+  docker:
+    # the Docker image with Cypress dependencies
+    - image: python:3.7
+      environment:
+        ## this enables colors in the output
+        TERM: xterm
+
+# Base python 2 setup 
+python2: &python2
+  working_directory: ~/repo
+  docker:
+    # the Docker image with Cypress dependencies
+    - image: python:2.7
+      environment:
+        ## this enables colors in the output
+        TERM: xterm
+
 jobs:
+  build:
+    # Main build process
+    <<: *python3
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          name: Pip Install
+          command: pip install -r requirements.txt
+      - save_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.6/site-packages"
+      - run:
+          name: Build dist
+          command: python setup.py sdist bdist_wheel
+      - run:
+          name: Check dist
+          command: python -m twine check dist/*
+       - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - dist
+
   test_python2:
     # Main build process
-    working_directory: ~/repo
-    docker:
-      # the Docker image with Cypress dependencies
-      - image: python:2.7
-        environment:
-          ## this enables colors in the output
-          TERM: xterm
+    <<: *python2
     steps:
       - checkout
       - restore_cache:
@@ -33,13 +73,7 @@ jobs:
 
   test_python3:
     # Main build process
-    working_directory: ~/repo
-    docker:
-      # the Docker image with Cypress dependencies
-      - image: python:3.7
-        environment:
-          ## this enables colors in the output
-          TERM: xterm
+    <<: *python3
     steps:
       - checkout
       - restore_cache:
@@ -61,9 +95,58 @@ jobs:
           path: test-results
           destination: tr1
 
+  deploy_test:
+    # Main build process
+    <<: *python3
+    steps:
+      # Checkout git repo
+      - checkout
+      # Attach the public repo created in the build task
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Upload to PYPI test
+          command: python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+  
+  deploy:
+    # Main build process
+    <<: *python3
+    steps:
+      # Checkout git repo
+      - checkout
+      # Attach the public repo created in the build task
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Upload to PYPI
+          command: python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+
 workflows:
   version: 2
   build_and_test:
     jobs:
+      - build
       - test_python2
       - test_python3
+      - deploy_test:
+          requires:
+            - build
+            - test_python2
+            - test_python3
+          filters:
+            branches:
+              only: master
+  deploy:
+    jobs:
+      - hold:
+          type: approval
+          requires:
+            - deploy_test
+          filters:
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - hold
+
+    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 
-# Base python 3 setup 
+# Base python 3 setup
 python3: &python3
   working_directory: ~/repo
   docker:
@@ -10,7 +10,7 @@ python3: &python3
         ## this enables colors in the output
         TERM: xterm
 
-# Base python 2 setup 
+# Base python 2 setup
 python2: &python2
   working_directory: ~/repo
   docker:
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Check dist
           command: python -m twine check dist/*
-       - persist_to_workspace:
+      - persist_to_workspace:
           root: ~/repo
           paths:
             - dist
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: Upload to PYPI test
           command: python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-  
+
   deploy:
     # Main build process
     <<: *python3
@@ -148,5 +148,3 @@ workflows:
       - deploy:
           requires:
             - hold
-
-    

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,23 @@ PYTHON_2_BUILD := python2
 PYTHON_3_BUILD := python3
 
 .PHONY: dev-build
-dev-build:
+dev-build: ## Build the docker boxes required to test the build
 	docker-compose build
 
 .PHONY: dev-test
-dev-test:
+dev-test: ## Run package tests in both Python 2 & 3
 	docker-compose run --rm $(PYTHON_2_BUILD) python test.py
 	docker-compose run --rm $(PYTHON_3_BUILD) python test.py
 
-package:
+package: ## Generate a dist package to send to pypi and check it is valid
 	docker-compose run --rm $(PYTHON_3_BUILD) python setup.py sdist bdist_wheel
+	docker-compose run $(PYTHON_3_BUILD) python -m twine check dist/*
 
-.PHONY: upload
-upload:
+.PHONY: upload-test
+upload-test: ## Upload the dist package to pypi test server
 	docker-compose run $(PYTHON_3_BUILD) python -m twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
+.PHONY: upload
+upload: ## Upload the dist package to pypi server
+	docker-compose run $(PYTHON_3_BUILD) python -m twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
+
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -7,27 +8,26 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version='2.0.0',            # Update the version number for new releases
-    name='heroku-kafka',        # This is the name of your PyPI-package.
-    description='Python kafka package for use with heroku\'s kafka.',
+    version="2.1.0",  # Update the version number for new releases
+    name="heroku-kafka",  # This is the name of your PyPI-package.
+    description="Python kafka package for use with heroku's kafka.",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Intended Audience :: Developers',
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Intended Audience :: Developers",
     ],
-    url='https://github.com/HubbleHQ/heroku-kafka',
-    author='Hubble',
-    author_email='dev@hubblehq.com',
-    license='MIT',
+    url="https://github.com/HubbleHQ/heroku-kafka",
+    author="Hubble",
+    author_email="dev@hubblehq.com",
+    license="MIT",
     py_modules=["heroku_kafka"],
-    install_requires=[
-        'kafka-python==1.4.6',
-    ]
+    install_requires=["kafka-python==1.4.6"],
 )


### PR DESCRIPTION
Update makefile so that you can do twine uploads to test and live  …
Previously the makefile was only uploading to test, which I didn't have
user credentials for, which then wasn't working and I was very baffled.

I have now setup a user account on test pypi so we can upload to test
and live, i've also changed the makefile so it runs a twine package
check after it builds the package for quick feedback as to weather it
will upload and detailed information if anything goes wrong.