### PR TITLE
Fix deploy bugs and deploy will now happen automatically on merge with master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,10 +153,12 @@ workflows:
             - build
             - test_python2
             - test_python3
-      - hold:
-          type: approval
-          requires:
-            - deploy_test
+          filters:
+            branches:
+              only: master
       - deploy:
           requires:
-            - hold
+            - deploy_test
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,18 +153,12 @@ workflows:
             - build
             - test_python2
             - test_python3
-          filters:
-            branches:
-              only: master
   deploy:
     jobs:
       - hold:
           type: approval
           requires:
             - deploy_test
-          filters:
-            branches:
-              only: master
       - deploy:
           requires:
             - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,6 @@ workflows:
             - build
             - test_python2
             - test_python3
-  deploy:
-    jobs:
       - hold:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,16 @@ jobs:
     steps:
       # Checkout git repo
       - checkout
+      - restore_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          name: Pip Install
+          command: pip install -r requirements.txt
+      - save_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.6/site-packages"
       # Attach the public repo created in the build task
       - attach_workspace:
           at: ~/repo
@@ -114,6 +124,16 @@ jobs:
     steps:
       # Checkout git repo
       - checkout
+      - restore_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          name: Pip Install
+          command: pip install -r requirements.txt
+      - save_cache:
+          key: deps3_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.6/site-packages"
       # Attach the public repo created in the build task
       - attach_workspace:
           at: ~/repo

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="2.1.1",  # Update the version number for new releases
+    version="2.1.2",  # Update the version number for new releases
     name="heroku-kafka",  # This is the name of your PyPI-package.
     description="Python kafka package for use with heroku's kafka.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="2.1.0",  # Update the version number for new releases
+    version="2.1.1",  # Update the version number for new releases
     name="heroku-kafka",  # This is the name of your PyPI-package.
     description="Python kafka package for use with heroku's kafka.",
     long_description=long_description,


### PR DESCRIPTION
Both of the deploy methods I thought wouldn't need the pip packages as
they had already been built however twine is a package that is required
for the deployment so I added it back in!

Decided to auto deploy to master as it makes things easier and I would like to go more towards continuous deployment. This package is fully tested and will only get deployed to live if it is deployable to test, passes all the tests and has the dist built properly.