### PR TITLE
ci: Add docker auth to Circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ python3: &python3
   docker:
     # the Docker image with Cypress dependencies
     - image: python:3.7
+      auth:
+        username: $DOCKERHUB_USER
+        password: $DOCKERHUB_PASSWORD
       environment:
         ## this enables colors in the output
         TERM: xterm
@@ -16,6 +19,9 @@ python2: &python2
   docker:
     # the Docker image with Cypress dependencies
     - image: python:2.7
+      auth:
+        username: $DOCKERHUB_USER
+        password: $DOCKERHUB_PASSWORD
       environment:
         ## this enables colors in the output
         TERM: xterm
@@ -145,10 +151,18 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
-      - test_python2
-      - test_python3
+      - build:
+          context:
+            - hubblehq-docker
+      - test_python2:
+          context:
+            - hubblehq-docker
+      - test_python3:
+          context:
+            - hubblehq-docker
       - deploy_test:
+          context:
+            - hubblehq-docker
           requires:
             - build
             - test_python2
@@ -157,6 +171,8 @@ workflows:
             branches:
               only: master
       - deploy:
+          context:
+            - hubblehq-docker
           requires:
             - deploy_test
           filters:


### PR DESCRIPTION
Docker will start rate limiting unauthenticated image pulls on November 1. This
change adds a Hubble docker account to our Circle configs, so that we don't get
throttled by Circle's pool of shared IP addresses.