### PR TITLE
[ch417] Remove python2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,19 +13,6 @@ python3: &python3
         ## this enables colors in the output
         TERM: xterm
 
-# Base python 2 setup
-python2: &python2
-  working_directory: ~/repo
-  docker:
-    # the Docker image with Cypress dependencies
-    - image: python:2.7
-      auth:
-        username: $DOCKERHUB_USER
-        password: $DOCKERHUB_PASSWORD
-      environment:
-        ## this enables colors in the output
-        TERM: xterm
-
 jobs:
   build:
     # Main build process
@@ -52,30 +39,6 @@ jobs:
           root: ~/repo
           paths:
             - dist
-
-  test_python2:
-    # Main build process
-    <<: *python2
-    steps:
-      - checkout
-      - restore_cache:
-          key: deps2_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
-      - run:
-          name: Pip Install
-          command: pip install -r requirements.txt
-      - save_cache:
-          key: deps2_7-{{ .Branch }}-{{ checksum "requirements.txt" }}
-          paths:
-            - "/usr/local/bin"
-            - "/usr/local/lib/python2.7/site-packages"
-      - run:
-          name: Run Tests
-          command: python test.py
-      - store_test_results:
-          path: test-results
-      - store_artifacts:
-          path: test-results
-          destination: tr1
 
   test_python3:
     # Main build process
@@ -154,9 +117,6 @@ workflows:
       - build:
           context:
             - hubblehq-docker
-      - test_python2:
-          context:
-            - hubblehq-docker
       - test_python3:
           context:
             - hubblehq-docker
@@ -165,7 +125,6 @@ workflows:
             - hubblehq-docker
           requires:
             - build
-            - test_python2
             - test_python3
           filters:
             branches:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export PROJECT_NAME := $(notdir $(CURDIR))
-PYTHON_2_BUILD := python2
 PYTHON_3_BUILD := python3
 
 .PHONY: dev-build
@@ -8,7 +7,6 @@ dev-build: ## Build the docker boxes required to test the build
 
 .PHONY: dev-test
 dev-test: ## Run package tests in both Python 2 & 3
-	docker-compose run --rm $(PYTHON_2_BUILD) python test.py
 	docker-compose run --rm $(PYTHON_3_BUILD) python test.py
 
 package: ## Generate a dist package to send to pypi and check it is valid

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,5 @@
 version: "3"
 services:
-  python2:
-    build:
-      context: .
-      dockerfile: ./dockerfiles/python2.7/Dockerfile
-    env_file:
-      - .env
-    volumes:
-      - .:/src
-    stdin_open: true
-    tty: true
   python3:
     build:
       context: .

--- a/dockerfiles/python2.7/Dockerfile
+++ b/dockerfiles/python2.7/Dockerfile
@@ -1,8 +1,0 @@
-FROM python:2.7
-ENV PYTHONUNBUFFERED 1
-
-RUN mkdir /src
-WORKDIR /src
-
-COPY . .
-RUN pip install -r requirements.txt


### PR DESCRIPTION
We don't use Python 2 anymore, and some dependency upgrades require that we drop it entirely.