### PR TITLE
[ch424] Prepare heroku-kafka for release on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Intended Audience :: Developers",
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-    version="2.1.4",  # Update the version number for new releases
+    version="3.0.0",  # Update the version number for new releases
     name="heroku-kafka",  # This is the name of your PyPI-package.
     description="Python kafka package for use with heroku's kafka.",
     long_description=long_description,


### PR DESCRIPTION
* Remove Python 2.7 support spec from `setup.py` so it doesn't show as supporting Python 2 on PyPI/pip
* Bump version to 3.0.0 (removing Python 2 is a breaking change, so major version bump)